### PR TITLE
fix: create preset from current settings when expander is false

### DIFF
--- a/Modules/LuxEditor/LuxEditor/Components/Infos.xaml.cs
+++ b/Modules/LuxEditor/LuxEditor/Components/Infos.xaml.cs
@@ -267,7 +267,7 @@ namespace LuxEditor.Components
                 var exp = new Expander
                 {
                     Header = title,
-                    IsExpanded = false,
+                    IsExpanded = true,
                     HorizontalAlignment = HorizontalAlignment.Stretch,
                     CornerRadius = new Microsoft.UI.Xaml.CornerRadius(4)
                 };
@@ -356,7 +356,7 @@ namespace LuxEditor.Components
             var curvesExp = new Expander
             {
                 Header = "Tone Curves",
-                IsExpanded = false,
+                IsExpanded = true,
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 CornerRadius = new Microsoft.UI.Xaml.CornerRadius(4)
             };
@@ -402,7 +402,7 @@ namespace LuxEditor.Components
             var maskExp = new Expander
             {
                 Header = "Layer Masks",
-                IsExpanded = false,
+                IsExpanded = true,
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 CornerRadius = new Microsoft.UI.Xaml.CornerRadius(4)
             };
@@ -428,7 +428,7 @@ namespace LuxEditor.Components
                     var layerExp = new Expander
                     {
                         Header = layer.Name,
-                        IsExpanded = false,
+                        IsExpanded = true,
                         Margin = new Thickness(0, 4, 0, 0),
                         CornerRadius = new Microsoft.UI.Xaml.CornerRadius(4),
                         HorizontalAlignment = HorizontalAlignment.Stretch

--- a/Modules/LuxEditor/LuxEditor/Logic/PresetManager.cs
+++ b/Modules/LuxEditor/LuxEditor/Logic/PresetManager.cs
@@ -135,7 +135,7 @@ public sealed class PresetManager
                 }
                 img.LayerManager.SelectedLayer = img.LayerManager.Layers.FirstOrDefault();
                 img.SaveState();
-                
+
                 ImageManager.Instance.SelectImage(img);
             }
         }


### PR DESCRIPTION
**Name:** `Luxoria - Pull Request`  
**Title:** `[LDA] - (LuxEditor) fix: luxoria preset creation`  
**Assignees:**  @epi-noahg 

---

### **Description**

This pr fix the preset creation by default when the expander is not expanded, the child are not loaded and the settings are set to false

---

### **Checklist**

- [x] My code adheres to the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, especially in areas that might be unclear.
- [x] I have added or updated relevant documentation (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [x] All new and existing tests pass.
- [x] I have checked that my PR targets the `develop` branch.
- [x] My PR title follows the [conventional commits](https://www.conventionalcommits.org/) format.

---

### **Type of Change**

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (non-breaking changes to improve code quality)

---

### **Related Issues**

Fixes #500 

---